### PR TITLE
Optimize on_apply_cmd & on_flush_apply & truncate value_with_ttl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,7 +313,7 @@ rpath = false
 [profile.release]
 opt-level = 3
 debug = false
-codegen-units = 16
+codegen-units = 1
 lto = "thin"
 incremental = false
 panic = 'unwind'

--- a/components/cdc/src/metrics.rs
+++ b/components/cdc/src/metrics.rs
@@ -116,4 +116,32 @@ lazy_static! {
         &["type"]
     )
     .unwrap();
+    pub static ref CDC_OBSERVER_DURATION: HistogramVec = register_histogram_vec!(
+        "tikv_cdc_observer_duration_seconds",
+        "Bucketed histogram of cdc observer duration.",
+        &["type"],
+        exponential_buckets(1e-7, 2.0, 20).unwrap() // 100ns ~ 100ms
+    )
+    .unwrap();
+}
+
+#[derive(Clone)]
+pub struct CdcLocalMetrics {
+    pub on_apply_cmd: local::LocalHistogram,
+}
+
+impl Default for CdcLocalMetrics {
+    fn default() -> Self {
+        Self {
+            on_apply_cmd: CDC_OBSERVER_DURATION
+                .with_label_values(&["on_apply_cmd"])
+                .local(),
+        }
+    }
+}
+
+impl CdcLocalMetrics {
+    pub fn flush(&self) {
+        self.on_apply_cmd.flush();
+    }
 }

--- a/components/cdc/src/metrics.rs
+++ b/components/cdc/src/metrics.rs
@@ -128,6 +128,11 @@ lazy_static! {
 #[derive(Clone)]
 pub struct CdcLocalMetrics {
     pub on_apply_cmd: local::LocalHistogram,
+    pub on_apply_cmd_1: local::LocalHistogram,
+
+    pub on_flush_apply: local::LocalHistogram,
+    pub on_flush_apply_1: local::LocalHistogram,
+    pub on_flush_apply_2: local::LocalHistogram,
 }
 
 impl Default for CdcLocalMetrics {
@@ -136,6 +141,18 @@ impl Default for CdcLocalMetrics {
             on_apply_cmd: CDC_OBSERVER_DURATION
                 .with_label_values(&["on_apply_cmd"])
                 .local(),
+            on_apply_cmd_1: CDC_OBSERVER_DURATION
+                .with_label_values(&["on_apply_cmd_1"])
+                .local(),
+            on_flush_apply: CDC_OBSERVER_DURATION
+                .with_label_values(&["on_flush_apply"])
+                .local(),
+            on_flush_apply_1: CDC_OBSERVER_DURATION
+                .with_label_values(&["on_flush_apply_1"])
+                .local(),
+            on_flush_apply_2: CDC_OBSERVER_DURATION
+                .with_label_values(&["on_flush_apply_2"])
+                .local(),
         }
     }
 }
@@ -143,5 +160,9 @@ impl Default for CdcLocalMetrics {
 impl CdcLocalMetrics {
     pub fn flush(&self) {
         self.on_apply_cmd.flush();
+        self.on_apply_cmd_1.flush();
+        self.on_flush_apply.flush();
+        self.on_flush_apply_1.flush();
+        self.on_flush_apply_2.flush();
     }
 }

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -135,43 +135,45 @@ impl<E: KvEngine> CmdObserver<E> for CdcObserver {
             .push(CmdBatch::new(observe_id, region_id));
     }
 
-    fn on_apply_cmd(&self, observe_id: ObserveID, region_id: u64, cmd: Cmd) {
-        let t = tikv_util::time::Instant::now();
+    fn on_apply_cmd(&self, observe_id: ObserveID, region_id: u64, cmd: &Cmd) {
         debug!("(rawkv)CdcObserver::on_apply_cmd"; "region_id" => region_id, "cmd" => ?cmd);
         self.cmd_batches
             .borrow_mut()
             .last_mut()
             .expect("should exist some cmd batch")
-            .push(observe_id, region_id, cmd);
-
-        self.cdc_metrics
-            .on_apply_cmd
-            .observe(t.saturating_elapsed_secs());
+            .push(observe_id, region_id, cmd.clone());
     }
 
-    fn on_flush_apply(&self, engine: E) {
+    fn on_flush_apply(&self, engine: Option<E>) {
         debug!("(rawkv)CdcObserver::on_flush_apply"; "cmd_batches" => ?self.cmd_batches.borrow());
         fail_point!("before_cdc_flush_apply");
         if !self.cmd_batches.borrow().is_empty() {
             let batches = self.cmd_batches.replace(Vec::default());
-            let mut region = Region::default();
-            region.mut_peers().push(Peer::default());
-            // Create a snapshot here for preventing the old value was GC-ed.
-            let snapshot =
-                RegionSnapshot::from_snapshot(Arc::new(engine.snapshot()), Arc::new(region));
-            let reader = OldValueReader::new(snapshot);
-            let get_old_value = move |key, query_ts, old_value_cache: &mut OldValueCache| {
-                old_value::get_old_value(&reader, key, query_ts, old_value_cache)
-            };
+            let get_old_value: old_value::OldValueCallback;
+            if let Some(engine) = engine {
+                let mut region = Region::default();
+                region.mut_peers().push(Peer::default());
+                // Create a snapshot here for preventing the old value was GC-ed.
+                let snapshot =
+                    RegionSnapshot::from_snapshot(Arc::new(engine.snapshot()), Arc::new(region));
+                let reader = OldValueReader::new(snapshot);
+                get_old_value =
+                    Box::new(move |key, query_ts, old_value_cache: &mut OldValueCache| {
+                        old_value::get_old_value(&reader, key, query_ts, old_value_cache)
+                    });
+            } else {
+                get_old_value = Box::new(move |_, _, _| (None, None));
+            }
+
             if let Err(e) = self.sched.schedule(Task::MultiBatch {
                 multi: batches,
-                old_value_cb: Box::new(get_old_value),
+                old_value_cb: get_old_value,
             }) {
                 warn!("cdc schedule task failed"; "error" => ?e);
             }
         }
 
-        self.cdc_metrics.flush();
+        // self.cdc_metrics.flush();
     }
 }
 
@@ -291,9 +293,9 @@ mod tests {
             &observer,
             observe_id,
             0,
-            Cmd::new(0, RaftCmdRequest::default(), RaftCmdResponse::default()),
+            &Cmd::new(0, RaftCmdRequest::default(), RaftCmdResponse::default()),
         );
-        observer.on_flush_apply(engine);
+        observer.on_flush_apply(Some(engine));
 
         match rx.recv_timeout(Duration::from_millis(10)).unwrap().unwrap() {
             Task::MultiBatch { multi, .. } => {

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -241,9 +241,9 @@ pub trait CmdObserver<E>: Coprocessor {
     /// Hook to call after preparing for applying write requests.
     fn on_prepare_for_apply(&self, observe_id: ObserveID, region_id: u64);
     /// Hook to call after applying a write request.
-    fn on_apply_cmd(&self, observe_id: ObserveID, region_id: u64, cmd: Cmd);
+    fn on_apply_cmd(&self, observe_id: ObserveID, region_id: u64, cmd: &Cmd);
     /// Hook to call after flushing writes to db.
-    fn on_flush_apply(&self, engine: E);
+    fn on_flush_apply(&self, engine: Option<E>);
 }
 
 pub trait ReadIndexObserver: Coprocessor {

--- a/components/raftstore/src/store/local_metrics.rs
+++ b/components/raftstore/src/store/local_metrics.rs
@@ -418,6 +418,10 @@ pub struct CoprocessorMetrics {
     pub on_apply_cmd_1: LocalHistogram,
     pub on_apply_cmd_2: LocalHistogram,
     pub on_apply_cmd_3: LocalHistogram,
+
+    pub on_flush_apply_1: LocalHistogram,
+    pub on_flush_apply_2: LocalHistogram,
+    pub on_flush_apply_3: LocalHistogram,
 }
 
 impl Default for CoprocessorMetrics {
@@ -445,6 +449,16 @@ impl Default for CoprocessorMetrics {
             on_apply_cmd_3: COPROCESSOR_DURATION
                 .with_label_values(&["on_apply_cmd_3"])
                 .local(),
+
+            on_flush_apply_1: COPROCESSOR_DURATION
+                .with_label_values(&["on_flush_apply_1"])
+                .local(),
+            on_flush_apply_2: COPROCESSOR_DURATION
+                .with_label_values(&["on_flush_apply_2"])
+                .local(),
+            on_flush_apply_3: COPROCESSOR_DURATION
+                .with_label_values(&["on_flush_apply_3"])
+                .local(),
         }
     }
 }
@@ -459,5 +473,9 @@ impl CoprocessorMetrics {
         self.on_apply_cmd_1.flush();
         self.on_apply_cmd_2.flush();
         self.on_apply_cmd_3.flush();
+
+        self.on_flush_apply_1.flush();
+        self.on_flush_apply_2.flush();
+        self.on_flush_apply_3.flush();
     }
 }

--- a/components/raftstore/src/store/local_metrics.rs
+++ b/components/raftstore/src/store/local_metrics.rs
@@ -362,6 +362,7 @@ pub struct RaftMetrics {
     pub leader_missing: Arc<Mutex<HashSet<u64>>>,
     pub invalid_proposal: RaftInvalidProposeMetrics,
     pub pre_propose_coprocessor: LocalHistogram,
+    pub pre_propose_coprocessor_1: LocalHistogram,
 }
 
 impl Default for RaftMetrics {
@@ -381,6 +382,9 @@ impl Default for RaftMetrics {
             pre_propose_coprocessor: COPROCESSOR_DURATION
                 .with_label_values(&["on_pre_propose"])
                 .local(),
+            pre_propose_coprocessor_1: COPROCESSOR_DURATION
+                .with_label_values(&["on_pre_propose_1"])
+                .local(),
         }
     }
 }
@@ -397,6 +401,7 @@ impl RaftMetrics {
         self.message_dropped.flush();
         self.invalid_proposal.flush();
         self.pre_propose_coprocessor.flush();
+        self.pre_propose_coprocessor_1.flush();
         let mut missing = self.leader_missing.lock().unwrap();
         LEADER_MISSING.set(missing.len() as i64);
         missing.clear();
@@ -409,6 +414,10 @@ pub struct CoprocessorMetrics {
     pub on_prepare_apply: LocalHistogram,
     pub on_apply_cmd: LocalHistogram,
     pub on_flush_apply: LocalHistogram,
+
+    pub on_apply_cmd_1: LocalHistogram,
+    pub on_apply_cmd_2: LocalHistogram,
+    pub on_apply_cmd_3: LocalHistogram,
 }
 
 impl Default for CoprocessorMetrics {
@@ -426,6 +435,16 @@ impl Default for CoprocessorMetrics {
             on_flush_apply: COPROCESSOR_DURATION
                 .with_label_values(&["on_flush_apply"])
                 .local(),
+
+            on_apply_cmd_1: COPROCESSOR_DURATION
+                .with_label_values(&["on_apply_cmd_1"])
+                .local(),
+            on_apply_cmd_2: COPROCESSOR_DURATION
+                .with_label_values(&["on_apply_cmd_2"])
+                .local(),
+            on_apply_cmd_3: COPROCESSOR_DURATION
+                .with_label_values(&["on_apply_cmd_3"])
+                .local(),
         }
     }
 }
@@ -436,5 +455,9 @@ impl CoprocessorMetrics {
         self.on_prepare_apply.flush();
         self.on_apply_cmd.flush();
         self.on_flush_apply.flush();
+
+        self.on_apply_cmd_1.flush();
+        self.on_apply_cmd_2.flush();
+        self.on_apply_cmd_3.flush();
     }
 }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2922,10 +2922,10 @@ where
                 // to ensure observers get the latest values modified by calllback.
                 cb.invoke_pre_propose(req.mut_requests().as_mut_slice());
             }
-            poll_ctx
-                .raft_metrics
-                .pre_propose_coprocessor_1
-                .observe(t.saturating_elapsed_secs());
+            // poll_ctx
+            //     .raft_metrics
+            //     .pre_propose_coprocessor_1
+            //     .observe(t.saturating_elapsed_secs());
 
             poll_ctx.coprocessor_host.pre_propose(self.region(), req)?;
             poll_ctx

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2922,6 +2922,11 @@ where
                 // to ensure observers get the latest values modified by calllback.
                 cb.invoke_pre_propose(req.mut_requests().as_mut_slice());
             }
+            poll_ctx
+                .raft_metrics
+                .pre_propose_coprocessor_1
+                .observe(t.saturating_elapsed_secs());
+
             poll_ctx.coprocessor_host.pre_propose(self.region(), req)?;
             poll_ctx
                 .raft_metrics

--- a/components/resolved_ts/src/resolver.rs
+++ b/components/resolved_ts/src/resolver.rs
@@ -55,7 +55,7 @@ impl Resolver {
         let key: Arc<[u8]> = key.into_boxed_slice().into();
         if self.locks_by_key.contains_key(&key) {
             // (rawkv) Happens when a second request with same key is proposed before the first one is applied.
-            warn!(
+            debug!(
                 "duplicated track lock {}@{}, region {}, skip",
                 &log_wrappers::Value::key(&key),
                 start_ts,

--- a/src/storage/raw/ttl.rs
+++ b/src/storage/raw/ttl.rs
@@ -3,7 +3,7 @@
 use crate::storage::kv::{Iterator, Result, Snapshot, TTL_TOMBSTONE};
 use crate::storage::Statistics;
 
-use engine_traits::util::{get_expire_ts, strip_extended_fields, truncate_extended_fields};
+use engine_traits::util::{get_expire_ts, strip_extended_fields, ExtendedFields};
 use engine_traits::CfName;
 use engine_traits::{IterOptions, ReadOptions};
 use txn_types::{Key, Value};
@@ -40,13 +40,14 @@ pub struct TTLSnapshot<S: Snapshot> {
 impl<S: Snapshot> TTLSnapshot<S> {
     fn map_value(&self, value_with_ttl: Result<Option<Value>>) -> Result<Option<Value>> {
         match value_with_ttl? {
-            Some(mut v) => {
-                let expire_ts = get_expire_ts(&v)?;
-                if expire_ts != 0 && expire_ts <= self.current_ts {
-                    return Ok(None);
-                }
-                truncate_extended_fields(&mut v).unwrap();
-                Ok(Some(v))
+            Some(v) => {
+                // let expire_ts = get_expire_ts(&v)?;
+                // if expire_ts != 0 && expire_ts <= self.current_ts {
+                //     return Ok(None);
+                // }
+                // truncate_extended_fields(&mut v).unwrap();
+                // Ok(Some(v))
+                Ok(ExtendedFields::extract_value(v, self.current_ts)?)
             }
             None => Ok(None),
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
* Optimize `on_apply_cmd` by reducing times of `Cmd::clone()`
* Optimize `on_flush_apply` by eliminating clone of `engine` and creation of `snapshot`
* Optimize `truncate value_with_ttl` by eliminating an extra parsing of extended fields
